### PR TITLE
Update Portfolio page with new card design

### DIFF
--- a/app/(DashboardLayout)/page.tsx
+++ b/app/(DashboardLayout)/page.tsx
@@ -2,13 +2,61 @@
 
 import PageContainer from "@/app/(DashboardLayout)/components/container/PageContainer";
 import DashboardCard from "@/app/(DashboardLayout)/components/shared/DashboardCard";
-import { Typography } from "@mui/material";
+import { Box, Card, CardContent, IconButton, Typography } from "@mui/material";
+import { IconCopy } from "@tabler/icons-react";
+import React from "react";
+
+const card = (
+	<React.Fragment>
+		<CardContent>
+			<Typography component="div" variant="overline">
+				PORTFOLIO VALUE
+			</Typography>
+			<Typography component="div" sx={{ mb: 1 }} variant="h4">
+				$0.00
+			</Typography>
+			<Typography variant="body2">0 MYC</Typography>
+			<Box
+				sx={{
+					alignItems: "center",
+					display: "flex",
+					justifyContent: "space-between",
+					mt: 2,
+				}}
+			>
+				<Typography sx={{ opacity: 0.7 }} variant="caption">
+					0x1F7B...b401
+				</Typography>
+				<Box>
+					<IconButton size="small" sx={{ color: "white" }}>
+						<IconCopy />
+					</IconButton>
+				</Box>
+			</Box>
+		</CardContent>
+	</React.Fragment>
+);
 
 const PortfolioPage = () => {
 	return (
 		<PageContainer description="this is Portfolio page" title="Portfolio">
-			<DashboardCard title="Portfolio">
-				<Typography>This is a Portfolio page</Typography>
+			<DashboardCard title="My MYC balance">
+				<div>
+					<Card
+						sx={{
+							background: "linear-gradient(45deg, #6a11cb 30%, #2575fc 90%)",
+							borderRadius: 4,
+							color: "white",
+							maxWidth: 300,
+							mb: 2,
+						}}
+					>
+						{card}
+					</Card>
+					<Typography variant="subtitle1">
+						Tip: You can also send your MYC from another wallet!
+					</Typography>
+				</div>
 			</DashboardCard>
 		</PageContainer>
 	);


### PR DESCRIPTION
This pull request updates the Portfolio page with a new card design. The design includes a card displaying the portfolio value, MYC balance, and wallet address. Additionally, a tip has been added to inform users that they can send MYC from another wallet.